### PR TITLE
add encryption/decryption support, fix lots of corner cases, some refactorings/renames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ cache:
 install:
   - PATH="$HOME/bin:$PATH"
   - export LD_LIBRARY_PATH="$HOME/lib:${LD_LIBRARY_PATH}"
-  - util/custom-gpg.sh
-  - gpg2 --version
   - pip install -U tox
+  - gpg2 --version
+#  - util/custom-gpg.sh
 
-# if we install gpg2 here we get 2.0 which does not work with the lib.
 before_install:
+    - sudo apt-get install gnupg2
     - sudo apt-get install rng-tools
     - sudo rngd -r /dev/urandom
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@
 - #22 introduce account.encrypt_mime and account.decrypt_mime API
   (not yet exposed to cmdline).
 
+- make tests work against gpg 2.0.21, gpg-2.1.11 (and likely higher
+  versions but those are hard to custom-build on ubuntu or older debian
+  machines)
+
 
 0.7.0
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@
   all state changes (and in particular Autocrypt header processing)
   is tracked in immutable entries.
 
+- with gpg2 we now internally use a hardcoded passphrase to avoid
+  problems with gpg-2.1.11 on ubuntu 16.04 which does not seem
+  to allow no-passphrase operations very well.
+
 
 0.7.0
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@
   problems with gpg-2.1.11 on ubuntu 16.04 which does not seem
   to allow no-passphrase operations very well.
 
+- #22 introduce account.encrypt_mime and account.decrypt_mime API
+  (not yet exposed to cmdline).
+
 
 0.7.0
 -------

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import six
 from attr import attrs, attrib
+import email
 import uuid
 import time
 from .bingpg import cached_property, BinGPG

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -179,36 +179,6 @@ class AccountManager(object):
             assert account.ownstate.keyhandle
             return headername + account.make_ac_header(emailadr)
 
-    def process_incoming(self, msg, delivto=None):
-        """ match account for incoming mail message
-        and defer to account.process_incoming.
-        :type msg: email.message.Message
-        :param msg: instance of a standard email Message.
-        :rtype: ProcessIncomingResult
-        """
-        if delivto is None:
-            _, delivto = mime.parse_email_addr(msg.get("Delivered-To"))
-            assert delivto
-        account = self.get_account_from_emailadr(delivto, raising=True)
-        return account.process_incoming(msg)
-
-    def process_outgoing(self, msg):
-        """ process outgoing mail message and add Autocrypt
-        header if it doesn't already exist.
-
-        :type msg: email.message.Message
-        :param msg: instance of a standard email Message.
-        :rtype: ProcessOutgoingResult
-        """
-        _, addr = mime.parse_email_addr(msg["From"])
-        account = self.get_account_from_emailadr(addr)
-        if account is not None:
-            return account.process_outgoing(msg)
-        else:
-            return ProcessOutgoingResult(
-                account=None, msg=msg, addr=addr,
-                had_autocrypt=None, added_autocrypt=None)
-
 
 class Account:
     """ An Account manages all Autocrypt settings (both own keys and

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -16,7 +16,7 @@ import time
 from .bingpg import cached_property, BinGPG
 from . import mime
 from .states import States
-from .myattr import attrib_text
+from .myattr import attrib_text, attrib_float
 import email.utils
 
 
@@ -308,7 +308,8 @@ class Account:
             prefer_encrypt=r.prefer_encrypt, keydata=r.keydata, keyhandle=keyhandle,
         )
         return ProcessIncomingResult(
-            msgid=msg_id,
+            msg_id=msg_id,
+            msg_date=msg_date,
             pah=r,
             peerstate=peerstate,
             account=self,
@@ -374,9 +375,10 @@ class EncryptMimeResult(object):
 
 @attrs
 class ProcessIncomingResult(object):
-    msgid = attrib_text()
+    msg_id = attrib_text()
+    msg_date = attrib_float()
     peerstate = attrib()
-    account = attrib(type=six.text_type)
+    account = attrib()
     pah = attrib()
 
 

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -153,8 +153,7 @@ class AccountManager(object):
 
     def make_header(self, emailadr, headername="Autocrypt: "):
         """ return an Autocrypt header line which uses our own
-        key and the provided emailadr if this account is managing
-        the emailadr.
+        key and the provided emailadr if one of our account matches it.
 
         :type emailadr: unicode
         :param emailadr:
@@ -178,7 +177,7 @@ class AccountManager(object):
             return ""
         else:
             assert account.ownstate.keyhandle
-            return account.make_ac_header(emailadr, headername=headername)
+            return headername + account.make_ac_header(emailadr)
 
     def process_incoming(self, msg, delivto=None):
         """ match account for incoming mail message
@@ -292,8 +291,8 @@ class Account:
                 "AccountManager directory {!r} not initialized".format(self.dir))
         return BinGPG(homedir=gpghome, gpgpath=self.ownstate.gpgbin)
 
-    def make_ac_header(self, emailadr, headername="Autocrypt: "):
-        return headername + mime.make_ac_header_value(
+    def make_ac_header(self, emailadr):
+        return mime.make_ac_header_value(
             addr=emailadr,
             keydata=self.bingpg.get_public_keydata(self.ownstate.keyhandle),
             prefer_encrypt=self.ownstate.prefer_encrypt,
@@ -356,7 +355,7 @@ class Account:
         if "Autocrypt" in msg:
             added_autocrypt = None
         else:
-            msg["Autocrypt"] = added_autocrypt = self.make_ac_header(addr, "")
+            msg["Autocrypt"] = added_autocrypt = self.make_ac_header(addr)
         return ProcessOutgoingResult(
             msg=msg, account=self, addr=addr,
             added_autocrypt=added_autocrypt, had_autocrypt=msg["Autocrypt"]

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -75,7 +75,6 @@ class AccountManager(object):
 
     def get_account(self, account_name="default", check=True):
         self._ensure_init()
-        assert account_name.isalnum(), account_name
         account = Account(self._states, account_name)
         if check and not account.exists():
             raise AccountNotFound("account {!r} not known".format(account_name))
@@ -217,8 +216,9 @@ class Account:
     """
 
     def __init__(self, states, name):
-        """ shallo initializer. Call create() for initializing this
+        """ shallow initializer. Call create() for initializing this
         account. exists() tells whether that has happened already. """
+        assert name.isalnum(), name
         self.name = name
         self._states = states
         self.ownstate = self._states.get_ownstate(name)

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -14,17 +14,9 @@ import os
 import sys
 from subprocess import Popen, PIPE
 from contextlib import contextmanager
-from base64 import b64encode
 import tempfile
 import re
 iswin32 = sys.platform == "win32" or (getattr(os, '_name', False) == 'nt')
-
-
-def b64encode_u(x):
-    res = b64encode(x)
-    if isinstance(res, bytes):
-        res = res.decode("ascii")
-    return res
 
 
 def cached_property(f):
@@ -163,6 +155,7 @@ class BinGPG(object):
         # open the process with a C locale, pipe everything
         env = os.environ.copy()
         env["LANG"] = "C"
+        # env["LC_ALL"] = "en_US.UTF-8"
         popen = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=env)
 
         # some debugging info
@@ -174,7 +167,7 @@ class BinGPG(object):
         ret = popen.wait()
         if ret == 130:
             raise KeyboardInterrupt("detected in gpg invocation")
-        err = err.decode("utf8")
+        err = err.decode("utf-8")
         if encoding:
             out = out.decode(encoding)
         if ret != 0 or (strict and err):
@@ -303,11 +296,11 @@ class BinGPG(object):
             packets.append(last_package_type + (lines,))
         return packets
 
-    def get_public_keydata(self, keyhandle, armor=False, b64=False):
+    def get_public_keydata(self, keyhandle, armor=False):
         args = ["-a"] if armor else []
         args.extend(["--export-options=export-minimal", "--export", str(keyhandle)])
         out = self._gpg_out(args, strict=True, encoding=None)
-        return out if not b64 else b64encode_u(out)
+        return out
 
     def get_secret_keydata(self, keyhandle, armor=False):
         args = ["-a"] if armor else []

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -152,6 +152,7 @@ class BinGPG(object):
         while stdout output is returned decoded if encoding is set (default is "utf8").
         If you want binary stdout output specify encoding=None.
         """
+        assert input is None or isinstance(input, bytes)
         args = [self.gpgpath, "--batch"] + self._homedirflags
         # make sure we use unicode for all provided arguments
 

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -155,7 +155,7 @@ class BinGPG(object):
         # open the process with a C locale, pipe everything
         env = os.environ.copy()
         env["LANG"] = "C"
-        # env["LC_ALL"] = "en_US.UTF-8"
+        env["LC_ALL"] = "en_US.UTF-8"
         popen = Popen(args, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=env)
 
         # some debugging info

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -136,7 +136,7 @@ class BinGPG(object):
     @cached_property
     def _nopassphrase(self):
         return ((["--pinentry-mode=loopback"] if self.isgpg2 else []) +
-                ["--passphrase", "''"])
+                ["--passphrase", "123"])
 
     def _gpg_out(self, argv, input=None, strict=False, encoding="utf8"):
         return self._gpg_outerr(argv, input=input, strict=strict, encoding=encoding)[0]

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -127,6 +127,7 @@ class BinGPG(object):
 
     @cached_property
     def _nopassphrase(self):
+        return (["--passphrase", "123"])
         return ((["--pinentry-mode=loopback"] if self.isgpg2 else []) +
                 ["--passphrase", "123"])
 

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -204,7 +204,6 @@ class BinGPG(object):
             "Subkey-Type: RSA",
             "Subkey-Length: 2048",
             "Subkey-Usage: encrypt",
-            # "Name-Real: " + uid,
             "Name-Email: " + emailadr,
             "Expire-Date: 0",
             "%commit"
@@ -315,12 +314,16 @@ class BinGPG(object):
                     "--export-secret-key", keyhandle])
         return self._gpg_out(args, strict=True, encoding=None)
 
-    def encrypt(self, data, recipients):
-        recs = []
+    def encrypt(self, data, recipients, signkey=None, text=False):
+        opts = self._nopassphrase + ["--encrypt", "--always-trust"]
         for r in recipients:
-            recs.extend(["--recipient", r])
-        return self._gpg_out(recs + ["--encrypt", "--always-trust"], input=data,
-                             encoding=None)
+            opts.extend(["-r", r])
+        if signkey:
+            opts.extend(["--sign", "-u", signkey])
+        if text:
+            opts.extend(["--armor"])
+        print(opts)
+        return self._gpg_out(opts, input=data, encoding=None)
 
     def sign(self, data, keyhandle):
         args = self._nopassphrase + ["--detach-sign", "-u", keyhandle]

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -85,7 +85,7 @@ def bot_reply(ctx, smtp, fallback_delivto):
         Subject="Re: " + msg["Subject"],
         _extra={"In-Reply-To": msg["Message-ID"]},
         Autocrypt=account.make_header(delivto, headername=""),
-        body=six.text_type(log)
+        payload=six.text_type(log), charset="utf8",
     )
     if smtp:
         host, port = smtp.split(",")

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -44,12 +44,8 @@ def bot_reply(ctx, smtp, fallback_delivto):
 
     log = SimpleLog()
     with log.s("reading headers", raising=True):
-        _, delivto = mime.parse_email_addr(msg.get("Delivered-To"))
-        if not delivto and fallback_delivto:
-            _, delivto = mime.parse_email_addr(fallback_delivto)
-        if not delivto:
-            raise ValueError("could not determine my own delivered-to address")
-        log("determined my own Delivered-To: " + delivto)
+        delivto = mime.get_delivered_to(msg, fallback_delivto)
+        log("determined Delivered-To: " + delivto)
 
     maxheadershow = 60
 

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -63,13 +63,13 @@ def bot_reply(ctx, smtp, fallback_delivto):
 
     account = account_manager.get_account_from_emailadr(delivto)
     r = account.process_incoming(msg)
-    with log.s("processing your mail through muacrypt:"):
-        if r.autocrypt_header:
-            status = "found:\n" + str(r.peerstate)
+    with log.s("processed incoming mail for account {}:".format(r.account.name)):
+        if r.pah.error:
+            log(r.pah.error)
         else:
-            status = "no Autocrypt header found."
-        log("processed incoming mail for account '{}', {}".format(
-            r.account.name, status))
+            ps = r.peerstate
+            log("found peeraddr={} keyhandle={} prefer_encrypt={}".format(
+                ps.addr, ps.public_keyhandle, ps.prefer_encrypt))
 
     log("\n")
     log("have a nice day, {}".format(delivto))

--- a/muacrypt/cmdline.py
+++ b/muacrypt/cmdline.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import os
 import sys
-import time
 import subprocess
 import six
 import click

--- a/muacrypt/cmdline.py
+++ b/muacrypt/cmdline.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import os
 import sys
 import subprocess
-import six
 import click
 from .cmdline_utils import (
     get_account, get_account_manager, MyGroup, MyCommandUnknownOptions,
@@ -181,29 +180,17 @@ def make_header(ctx, emailadr):
     click.echo(account_manager.make_header(emailadr))
 
 
-@mycommand("set-prefer-encrypt")
-@account_option
-@click.argument("value", default=None, required=False,
-                type=click.Choice(["notset", "yes", "no"]))
-@click.pass_context
-def set_prefer_encrypt(ctx, account, value):
-    """print or set prefer-encrypted setting."""
-    account = get_account(ctx, account)
-    if value is None:
-        click.echo(account.config.prefer_encrypt)
-    else:
-        value = six.text_type(value)
-        account.config.set_prefer_encrypt(value)
-        click.echo("set prefer-encrypt to %r" % value)
-
-
 @mycommand("process-incoming")
 @click.pass_context
 def process_incoming(ctx):
-    """parse Autocrypt headers from stdin mail. """
+    """parse Autocrypt headers from stdin-read mime message
+    if it was delivered to one of our managed accounts.
+    """
     account_manager = get_account_manager(ctx)
     msg = mime.parse_message_from_file(sys.stdin)
-    r = account_manager.process_incoming(msg)
+    delivto = mime.get_delivered_to(msg)
+    account = account_manager.get_account_from_emailadr(delivto, raising=True)
+    r = account.process_incoming(msg)
     if r.peerstate.autocrypt_timestamp == r.peerstate.last_seen:
         msg = "found: " + str(r.peerstate)
     else:
@@ -215,18 +202,30 @@ def process_incoming(ctx):
 @mycommand("process-outgoing")
 @click.pass_context
 def process_outgoing(ctx):
-    """add Autocrypt header for outgoing mail.
+    """add Autocrypt header for outgoing mail if the From matches
+    a managed account.
 
-    We process mail from stdin by adding an Autocrypt
+    We read mail from stdin by adding an Autocrypt
     header and send the resulting message to stdout.
     If the mail from stdin contains an Autocrypt header we keep it
     for the outgoing message and do not add one.
     """
+    msg = _process_outgoing(ctx)
+    click.echo(msg.as_string())
+
+
+def _process_outgoing(ctx):
     account_manager = get_account_manager(ctx)
     msg = mime.parse_message_from_file(sys.stdin)
-    r = account_manager.process_outgoing(msg)
-    dump_info_outgoing_result(r)
-    click.echo(r.msg.as_string())
+    _, addr = mime.parse_email_addr(msg["From"])
+    account = account_manager.get_account_from_emailadr(addr)
+    if account is None:
+        log_info("No Account associated with addr={!r}".format(addr))
+        return msg
+    else:
+        r = account.process_outgoing(msg)
+        dump_info_outgoing_result(r)
+        return r.msg
 
 
 def dump_info_outgoing_result(r):
@@ -234,8 +233,6 @@ def dump_info_outgoing_result(r):
         log_info("Autocrypt header set for {!r}".format(r.addr))
     elif r.had_autocrypt:
         log_info("Found existing Autocrypt: {}...".format(r.had_autocrypt[:35]))
-    elif r.account is None:
-        log_info("No Account associated with addr={!r}".format(r.addr))
 
 
 @click.command(cls=MyCommandUnknownOptions)
@@ -253,12 +250,8 @@ def sendmail(ctx, args):
     "sendmail" program.
     """
     assert args
-    account_manager = get_account_manager(ctx)
     args = list(args)
-    msg = mime.parse_message_from_file(sys.stdin)
-    r = account_manager.process_outgoing(msg)
-    dump_info_outgoing_result(r)
-
+    msg = _process_outgoing(ctx)
     input = msg.as_string()
     # with open("/tmp/mail", "w") as f:
     #    f.write(input)

--- a/muacrypt/cmdline.py
+++ b/muacrypt/cmdline.py
@@ -217,7 +217,7 @@ def process_outgoing(ctx):
 def _process_outgoing(ctx):
     account_manager = get_account_manager(ctx)
     msg = mime.parse_message_from_file(sys.stdin)
-    _, addr = mime.parse_email_addr(msg["From"])
+    addr = mime.parse_email_addr(msg["From"])
     account = account_manager.get_account_from_emailadr(addr)
     if account is None:
         log_info("No Account associated with addr={!r}".format(addr))

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -208,6 +208,15 @@ def transfer_non_content_headers(msg, newmsg):
             newmsg[header] = value
 
 
+def get_delivered_to(msg, fallback_delivto=None):
+    _, delivto = parse_email_addr(msg.get("Delivered-To"))
+    if not delivto and fallback_delivto:
+        _, delivto = parse_email_addr(fallback_delivto)
+    if not delivto:
+        raise ValueError("could not determine my own delivered-to address")
+    return delivto
+
+
 # adapted from ModernPGP:memoryhole/generators/generator.py which
 # was adapted from notmuch:devel/printmimestructure
 def render_mime_structure(msg, prefix='└'):

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals, print_function
 import email.parser
 import base64
 from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
 from email.utils import formatdate, make_msgid
 from email.generator import _make_boundary
 import six
@@ -138,9 +139,11 @@ def gen_mail_msg(From, To, _extra=None, Autocrypt=None, Subject="testmail",
     if MessageID is None:
         MessageID = make_msgid()
 
-    # prefer plain ascii mails to keep mail files directly readable
-    # without base64-decoding etc.
-    msg = MIMEText(payload, _charset=charset)
+    if not isinstance(payload, list):
+        msg = MIMEText(payload or '', _charset=charset)
+    else:
+        msg = MIMEMultipart()
+        assert not payload
 
     msg['From'] = From
     msg['To'] = ",".join(To)
@@ -190,7 +193,7 @@ def make_message(content_type, payload=None):
     return msg
 
 
-def make_tp_message_from_msg(msg, _h=("content-transfer-encoding",)):
+def make_content_message_from_email(msg, _h=("content-transfer-encoding",)):
     newmsg = make_message(
         content_type=msg["Content-Type"],
         payload=msg.get_payload(decode=False)

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -8,6 +8,7 @@ import email.parser
 import base64
 from email.mime.text import MIMEText
 from email.utils import formatdate, make_msgid
+from email.generator import _make_boundary
 import six
 
 
@@ -128,7 +129,7 @@ def verify_ac_dict(ac_dict):
 
 
 def gen_mail_msg(From, To, _extra=None, Autocrypt=None, Subject="testmail",
-                 Date=None, _dto=False, MessageID=None, body='Autoresponse'):
+                 Date=None, _dto=False, MessageID=None, body='Autoresponse\n'):
     assert isinstance(To, (list, tuple))
     if MessageID is None:
         MessageID = make_msgid()
@@ -143,9 +144,9 @@ def gen_mail_msg(From, To, _extra=None, Autocrypt=None, Subject="testmail",
         charset = "utf-8"
     msg = MIMEText(body, _charset=charset)
 
-    msg['Message-ID'] = MessageID
     msg['From'] = From
     msg['To'] = ",".join(To)
+    msg['Message-ID'] = MessageID
     msg['Subject'] = Subject
     msg['Date'] = Date or formatdate()
     if _extra:
@@ -176,6 +177,10 @@ def decrypt_message(msg, bingpg):
             continue
         dec_msg.add_header(name, val)
     return dec_msg, err
+
+
+def gen_boundary():
+    return _make_boundary()
 
 
 # adapted from ModernPGP:memoryhole/generators/generator.py which

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -14,14 +14,6 @@ from email.generator import _make_boundary
 import six
 
 
-def encode_binary_keydata(keydata):
-    assert isinstance(keydata, bytes)
-    key = base64.b64encode(keydata)
-    if isinstance(key, bytes):
-        key = key.decode("ascii")
-    return key
-
-
 def decode_keydata(ascii_keydata):
     return base64.b64decode(ascii_keydata)
 
@@ -167,26 +159,6 @@ def gen_mail_msg(From, To, _extra=None, Autocrypt=None, Subject="testmail",
     if Autocrypt:
         msg["Autocrypt"] = Autocrypt
     return msg
-
-
-def decrypt_message(msg, bingpg):
-    # this method is not tested through the test suite
-    # currently because we lack a way to generate proper
-    # encrypted messages
-    ctype = msg.get_content_type()
-    assert ctype == "multipart/encrypted"
-    parts = msg.get_payload()
-    meta, enc = parts
-    assert meta.get_content_type() == "application/pgp-encrypted"
-    assert enc.get_content_type() == "application/octet-stream"
-
-    dec, err = bingpg.decrypt(enc.get_payload())
-    dec_msg = parse_message_from_string(dec)
-    for name, val in msg.items():
-        if name.lower() in ("content-type", "content-transfer-encoding"):
-            continue
-        dec_msg.add_header(name, val)
-    return dec_msg, err
 
 
 def gen_boundary():

--- a/muacrypt/myattr.py
+++ b/muacrypt/myattr.py
@@ -23,8 +23,10 @@ def attrib_bytes():
 
 
 def attrib_text_or_none():
-    return attrib(validator=v.instance_of((six.text_type, type(None))))
+    return attrib(validator=v.instance_of((six.text_type, type(None))),
+                  default=None)
 
 
 def attrib_bytes_or_none():
-    return attrib(validator=v.instance_of((bytes, type(None))))
+    return attrib(validator=v.instance_of((bytes, type(None))),
+                  default=None)

--- a/muacrypt/states.py
+++ b/muacrypt/states.py
@@ -54,7 +54,6 @@ class States:
         return sorted(self._heads._getheads(prefix=prefix))
 
     def get_peerstate(self, account_name, addr):
-        addr.encode("ascii")  # throw an exception if we have a non-ascii addr
         head_name = self._peer_pat.format(id=account_name, addr=addr)
         chain = self._makechain(head_name)
         return PeerState(chain)

--- a/muacrypt/states.py
+++ b/muacrypt/states.py
@@ -122,6 +122,10 @@ class PeerState(object):
         return getattr(self._latest_ac_entry(), "keyhandle", '')
 
     @property
+    def prefer_encrypt(self):
+        return getattr(self._latest_ac_entry(), "prefer_encrypt", '')
+
+    @property
     def public_keydata(self):
         return getattr(self._latest_ac_entry(), "keydata", b'')
 
@@ -136,12 +140,12 @@ class PeerState(object):
         return self._chain.latest_entry_of(MsgEntry)
 
     # methods which modify/add state
-    def update_from_msg(self, msg_id, effective_date, parsed_autocrypt_header,
+    def update_from_msg(self, msg_id, effective_date, prefer_encrypt,
                         keydata, keyhandle):
-        if parsed_autocrypt_header and effective_date >= self.autocrypt_timestamp:
+        if keydata and effective_date >= self.autocrypt_timestamp:
             self._append_ac_entry(
                 msg_id=msg_id, msg_date=effective_date,
-                prefer_encrypt=parsed_autocrypt_header["prefer-encrypt"],
+                prefer_encrypt=prefer_encrypt,
                 keydata=keydata or b'', keyhandle=keyhandle or '',
             )
         else:

--- a/muacrypt/states.py
+++ b/muacrypt/states.py
@@ -54,8 +54,7 @@ class States:
         return sorted(self._heads._getheads(prefix=prefix))
 
     def get_peerstate(self, account_name, addr):
-        # XXX encode addr?
-        assert addr.encode("ascii"), addr
+        addr.encode("ascii")  # throw an exception if we have a non-ascii addr
         head_name = self._peer_pat.format(id=account_name, addr=addr)
         chain = self._makechain(head_name)
         return PeerState(chain)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # vim:ts=4:sw=4:expandtab
-from __future__ import unicode_literals
 
 import logging
 import mailbox
@@ -256,8 +255,8 @@ def account_maker(tmpdir, gpgpath):
     # because gpg-2.1.11 chokes while trying to start gpg-agent
     count = itertools.count()
 
-    def maker(email_regex='.*', gpgmode='own', gpgbin=gpgpath):
-        bname = "ac%d" % next(count)
+    def maker(email_regex=u'.*', gpgmode=u'own', gpgbin=gpgpath):
+        bname = u"ac%d" % next(count)
         basedir = tmpdir.mkdir(bname).strpath
         states = States(basedir)
         account = Account(states, bname)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,12 +256,14 @@ def account_maker(tmpdir, gpgpath):
     count = itertools.count()
 
     def maker(email_regex=u'.*', gpgmode=u'own', gpgbin=gpgpath):
-        bname = u"ac%d" % next(count)
+        i = next(count)
+        bname = u"ac%d" % i
         basedir = tmpdir.mkdir(bname).strpath
         states = States(basedir)
         account = Account(states, bname)
         account.create(name=bname, email_regex=email_regex, gpgmode=gpgmode, gpgbin=gpgbin,
                        keyhandle=None)
+        account.addr = "%d@x.org" % (i, )
         return account
     return maker
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,10 +193,13 @@ def datadir(request):
             with self.open(name, "r") as f:
                 return f.read()
 
+        def get_mime(self, name):
+            with self.open(name, "rb") as f:
+                return mime.message_from_binary_file(f)
+
         def parse_ac_header_from_email(self, name):
-            with self.open(name) as fp:
-                msg = mime.parse_message_from_file(fp)
-                return mime.parse_one_ac_header_from_msg(msg)
+            msg = self.get_mime(name)
+            return mime.parse_one_ac_header_from_msg(msg)
 
     return D(request.fspath.dirpath("data"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 # vim:ts=4:sw=4:expandtab
 from __future__ import unicode_literals
 
-from click.testing import CliRunner
 import logging
 import shutil
 import os
@@ -109,6 +108,7 @@ def bingpg2(bingpg_maker):
 
 class ClickRunner:
     def __init__(self, main):
+        from click.testing import CliRunner
         self.runner = CliRunner()
         self._main = main
         self._rootargs = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import logging
+import mailbox
 import shutil
 import os
 import itertools
@@ -355,3 +356,18 @@ def popen_mock(monkeypatch):
 
     monkeypatch.setattr(subprocess, "Popen", MyPopen)
     return pm
+
+
+@pytest.fixture
+def maildir(tmpdir):
+    return Maildir(tmpdir.join("maildir").strpath)
+
+
+class Maildir:
+    def __init__(self, tmpdir):
+        self.maildir = mailbox.Maildir(tmpdir)
+
+    def store(self, msg):
+        self.maildir.add(msg)
+        logging.debug("stored msgid={} path: {}".format(
+            msg.get("message-id"), self.maildir._path))

--- a/tests/data/msg_8bit.eml
+++ b/tests/data/msg_8bit.eml
@@ -1,0 +1,9 @@
+From: Alice <alice@testsuite.autocrypt.org>
+To: Bob <bob@testsuite.autocrypt.org>
+Subject: an 8-bit test
+Date: Sat, 17 Dec 2016 10:07:48 +0100
+Message-ID: <8bit@testsuite.autocrypt.org>
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+this äöäqäwe

--- a/tests/data/msg_iso8859_quopri.eml
+++ b/tests/data/msg_iso8859_quopri.eml
@@ -1,0 +1,5 @@
+Content-Type: text/plain; charset=iso-8859-1
+Content-Disposition: inline
+Content-Transfer-Encoding: quoted-printable
+
+angeh=F6rt

--- a/tests/data/multipart_fn_unicode.eml
+++ b/tests/data/multipart_fn_unicode.eml
@@ -1,0 +1,21 @@
+Content-Type: multipart/mixed; boundary="59fce9df_3e33ed31_17c9"
+
+--59fce9df_3e33ed31_17c9
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+---------- =46orwarded message ----------
+=46rom: Delta Chat
+
+-- =20
+Now using Delta Chat. Please excuse my brevity :)
+--59fce9df_3e33ed31_17c9
+Content-Type: application/octet-stream
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; 
+ filename="Übersicht - Sicherheit, Privatsphäre und Nachhaltigkeit.pdf"
+
+JVBERi0xLjcKJcfsj6IKNSAwIG9iago8PC9MZW5ndGggNiAwIFIvRmlsdGVyIC9GbGF0ZURlY29k
+c3RhcnR4cmVmCjEwNjkwMgolJUVPRgo=
+
+--59fce9df_3e33ed31_17c9--

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -28,12 +28,12 @@ class TestAccount:
         addr = "alice@a.org"
         msg1 = mime.gen_mail_msg(
             From=addr, To=["b@b.org"],
-            Autocrypt=ac2.make_ac_header(addr, headername=""))
+            Autocrypt=ac2.make_ac_header(addr))
         r = ac1.process_incoming(msg1)
         assert r.peerstate.public_keyhandle == ac2.ownstate.keyhandle
         msg2 = mime.gen_mail_msg(
             From=addr, To=["b@b.org"],
-            Autocrypt=ac3.make_ac_header(addr, headername=""))
+            Autocrypt=ac3.make_ac_header(addr))
         r2 = ac1.process_incoming(msg2)
         assert r2.peerstate.public_keyhandle == ac3.ownstate.keyhandle
 
@@ -45,7 +45,7 @@ class TestAccount:
         addr = "alice@a.org"
         msg1 = mime.gen_mail_msg(
             From=addr, To=["b@b.org"], Date=later_date,
-            Autocrypt=account.make_ac_header(addr, ''),
+            Autocrypt=account.make_ac_header(addr),
         )
         r = account.process_incoming(msg1)
         assert r.peerstate.last_seen == fixed_time
@@ -54,10 +54,10 @@ class TestAccount:
         ac1, ac2, ac3 = account_maker(), account_maker(), account_maker()
         addr = "alice@a.org"
         msg2 = mime.gen_mail_msg(
-            From=addr, To=["b@b.org"], Autocrypt=ac3.make_ac_header(addr, ''),
+            From=addr, To=["b@b.org"], Autocrypt=ac3.make_ac_header(addr),
             Date='Thu, 16 Feb 2017 15:00:00 -0000')
         msg1 = mime.gen_mail_msg(
-            From=addr, To=["b@b.org"], Autocrypt=ac2.make_ac_header(addr, ''),
+            From=addr, To=["b@b.org"], Autocrypt=ac2.make_ac_header(addr),
             Date='Thu, 16 Feb 2017 13:00:00 -0000')
         r = ac1.process_incoming(msg2)
         assert r.account.get_peerstate(addr).public_keyhandle == ac3.ownstate.keyhandle
@@ -83,7 +83,7 @@ class TestAccount:
         addr = "a@a.org"
         msg = mime.gen_mail_msg(
             From=addr, To=["b@b.org"],
-            Autocrypt=ac1.make_ac_header(addr, headername=""))
+            Autocrypt=ac1.make_ac_header(addr))
         r = ac2.process_incoming(msg)
         assert r.peerstate.addr == addr
         enc = ac2.bingpg.encrypt(data=b"123", recipients=[r.peerstate.public_keyhandle])
@@ -97,16 +97,14 @@ class TestAccount:
         # send a mail from addr1 with autocrypt key to addr2
         msg = mime.gen_mail_msg(
             From=addr1, To=[addr2],
-            Autocrypt=ac1.make_ac_header(addr1, headername=""))
-        msg.set_type('text/plain')
-
+            Autocrypt=ac1.make_ac_header(addr1))
         r = ac2.process_incoming(msg)
         assert r.peerstate.addr == addr1
 
         # send an encrypted mail from addr2 to addr1
         msg2 = mime.gen_mail_msg(
             From=addr2, To=[addr1],
-            Autocrypt=ac2.make_ac_header(addr2, headername=""),
+            Autocrypt=ac2.make_ac_header(addr2),
             payload="hello ä umlaut", charset="utf8")
         r = ac1.process_incoming(msg2)
         assert r.peerstate.addr == addr2

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -27,13 +27,19 @@ class TestAccount:
         assert acc.export_secret_key()
 
     def test_parse_incoming_mail_broken_ac_header(self, account_maker):
-        addr = "a@a.org"
         acc1 = account_maker()
         msg = mime.gen_mail_msg(
-            From=addr, To=["b@b.org"], Autocrypt="Autocrypt: to=123; key=12312k3")
+            From=acc1.addr, To=[], Autocrypt="Autocrypt: to=123; key=12312k3")
         r = acc1.process_incoming(msg)
         assert r.pah.error
         assert r.msg_date
+
+    def test_parse_incoming_mail_empty_ac_header(self, account_maker):
+        acc1 = account_maker()
+        msg = mime.gen_mail_msg(From=acc1.addr, To=[])
+        msg["Autocrypt"] = ""
+        r = acc1.process_incoming(msg)
+        assert r.pah.error
 
     def test_parse_incoming_mail_broken_date_header(self, account_maker):
         addr = "a@a.org"
@@ -62,7 +68,7 @@ class TestAccount:
         assert r.pah.error
 
     def test_parse_incoming_mail_unicode_from(self, account_maker):
-        addr = b'x@k\366nig.de'
+        addr = 'x@k\366nig.de'
         acc1 = account_maker()
         msg = mime.gen_mail_msg(
             From=addr, To=["b@b.org"],

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -155,7 +155,7 @@ class TestAccount:
         with datadir.open("msg_8bit.eml", "rb") as f:
             msg = mime.message_from_binary_file(f)
         r1 = acc1.encrypt_mime(msg, [acc1.addr])
-        r2 = acc1.decrypt_mime(r1.msg)
+        r2 = acc1.decrypt_mime(r1.enc_msg)
         assert r2.dec_msg.get_payload(decode=True) == msg.get_payload(decode=True)
 
     def test_parse_incoming_mail_iso_quopri(self, account_maker, datadir):
@@ -164,7 +164,7 @@ class TestAccount:
         with datadir.open("msg_iso8859_quopri.eml", "rb") as f:
             msg = mime.message_from_binary_file(f)
         r1 = acc1.encrypt_mime(msg, [acc1.addr])
-        r2 = acc1.decrypt_mime(r1.msg)
+        r2 = acc1.decrypt_mime(r1.enc_msg)
         assert r2.dec_msg.get_payload(decode=True) == msg.get_payload(decode=True)
         s = r2.dec_msg.get_payload(decode=True)
         assert six.text_type(s, "iso-8859-1") == u"angehört\n"
@@ -181,10 +181,10 @@ class TestAccount:
         msg2 = gen_ac_mail_msg(acc2, acc1, payload="hello ä umlaut", charset="utf8")
 
         r = acc2.encrypt_mime(msg2, [acc1.addr])
-        acc1.process_incoming(r.msg)
+        acc1.process_incoming(r.enc_msg)
 
         # decrypt the incoming mail
-        r = acc1.decrypt_mime(r.msg)
+        r = acc1.decrypt_mime(r.enc_msg)
         dec = r.dec_msg
         assert dec.get_content_type() == "text/plain"
         assert dec.get_payload() == msg2.get_payload()
@@ -205,10 +205,10 @@ class TestAccount:
 
         # send multipart/mixed back to acc1
         r = acc2.encrypt_mime(msg2, [acc1.addr])
-        acc1.process_incoming(r.msg)
+        acc1.process_incoming(r.enc_msg)
 
         # decrypt the incoming mail
-        r = acc1.decrypt_mime(r.msg)
+        r = acc1.decrypt_mime(r.enc_msg)
         dec = r.dec_msg
         assert dec.get_content_type() == "multipart/mixed"
         assert len(dec.get_payload()) == 2

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -13,7 +13,7 @@ def ac_sender(manager_maker, request):
     manager = manager_maker(init=False)
     account = manager.add_account("sender", email_regex=request.param)
     account.adr = request.param
-    account.ac_headerval = account.make_ac_header(account.adr, headername="")
+    account.ac_headerval = account.make_ac_header(account.adr)
     assert account.ac_headerval
     return account
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -118,9 +118,9 @@ class TestBot:
         assert reply_msg["From"] == bcmd.bot_adr
         assert reply_msg["To"] == msg["From"]
         assert reply_msg["Autocrypt"]
-        ac_dict = mime.parse_ac_headervalue(reply_msg["Autocrypt"])
-        assert ac_dict["addr"] == bcmd.bot_adr
-        assert ac_dict["keydata"]
+        r = mime.parse_ac_headervalue(reply_msg["Autocrypt"])
+        assert r.addr == bcmd.bot_adr
+        assert r.keydata
         body = decode_body(reply_msg)
         assert "no Autocrypt header" not in body
         print(body)
@@ -137,7 +137,7 @@ class TestBot:
         assert reply_msg["Autocrypt"]
         body = decode_body(reply_msg)
         print(body)
-        assert "no autocrypt header" in body.lower()
+        assert "no valid autocrypt" in body.lower()
 
     @pytest.mark.parametrize("with_ac", [True, False])
     def test_send_reply(self, smtpserver, bcmd, ac_sender, with_ac, linematch):
@@ -164,7 +164,7 @@ class TestBot:
         """.format(msg["Message-ID"][:20]))
         if with_ac:
             linematch(body, """
-                *processed incoming*found:*
+                *processed incoming*
                 *{senderadr}*{senderkeyhandle}*
             """.format(
                 senderadr=ac_sender.adr,

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -87,6 +87,7 @@ class TestProcessIncoming:
         """, input=msg.as_string())
         mycmd.run_ok(["status"])
 
+
 class TestAccountCommands:
     def test_add_list_del_account(self, mycmd):
         mycmd.run_ok(["status"], """

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -23,10 +23,10 @@ def test_init_and_make_header(mycmd):
     adr = "x@yz.org"
     mycmd.run_ok(["add-account", "default", "--email-regex", adr])
     out = mycmd.run_ok(["make-header", adr])
-    d = mime.parse_one_ac_header_from_string(out)
+    r = mime.parse_one_ac_header_from_string(out)
     assert "prefer-encrypt" not in out
     assert "type" not in out
-    assert d["addr"] == adr
+    assert r.addr == adr
     out2 = mycmd.run_ok(["make-header", adr])
     assert out == out2
 

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -64,6 +64,17 @@ def test_get_delivered_to():
         mime.get_delivered_to(msg)
 
 
+@pytest.mark.parametrize("input,output", [
+    (b"Simple <x@x.org>", "x@x.org"),
+    (b"=?utf-8?Q?Bj=C3=B6rn?= <x@x.org>", "x@x.org"),
+    (b"x <x@i\366enig.net>", "x@i=F6enig.net"),
+])
+def test_parse_email_addr(input, output):
+    addr = mime.parse_email_addr(input)
+    assert isinstance(addr, six.text_type)
+    assert addr == output
+
+
 class TestEmailCorpus:
     def test_rsa2048_simple(self, datadir, bingpg):
         r = datadir.parse_ac_header_from_email("rsa2048-simple.eml")

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import six
 import pytest
 from muacrypt import mime
-from base64 import b64decode
+from base64 import b64encode
 
 
 def make_ac_dict(**kwargs):
@@ -36,21 +36,21 @@ def test_render(datadir):
 
 
 def test_make_and_parse_header_value():
-    addr, keydata = "x@xy.z", "123"
+    addr, keydata = "x@xy.z", b64encode(b'123')
     h = mime.make_ac_header_value(addr=addr, keydata=keydata)
-    d = mime.parse_ac_headervalue(h)
-    assert not mime.verify_ac_dict(d)
-    assert d == make_ac_dict(addr=addr, keydata=keydata)
+    r = mime.parse_ac_headervalue(h)
+    assert not r.error
+    assert r.keydata == keydata
+    assert r.addr == addr
+    assert not r.extra_attr
 
 
-def test_make_and_parse_header_errors():
-    addr, keydata = "x@xy.z", "123"
-    h = mime.make_ac_header_value(addr=addr, keydata=keydata,
-                                  prefer_encrypt="nopreference", keytype="9")
-    assert "prefer-encrypt" not in h, h
-    d = mime.parse_ac_headervalue(h)
-    assert "unknown key type" in mime.verify_ac_dict(d)[0]
-    assert d == make_ac_dict(addr=addr, keydata=keydata, type="9")
+def test_make_and_parse_header_prefer_encrypt():
+    addr, keydata = "x@xy.z", b64encode(b'123')
+    h = mime.make_ac_header_value(addr=addr, keydata=keydata, prefer_encrypt="notset")
+    r = mime.parse_ac_headervalue(h)
+    assert "notset" in r.error
+    assert not r.keydata
 
 
 def test_get_delivered_to():
@@ -66,29 +66,26 @@ def test_get_delivered_to():
 
 class TestEmailCorpus:
     def test_rsa2048_simple(self, datadir, bingpg):
-        d = datadir.parse_ac_header_from_email("rsa2048-simple.eml")
-        assert d["addr"] == "alice@testsuite.autocrypt.org", d
-        bingpg.import_keydata(b64decode(d["keydata"]))
+        r = datadir.parse_ac_header_from_email("rsa2048-simple.eml")
+        assert r.addr == "alice@testsuite.autocrypt.org", r
+        assert r.prefer_encrypt == "nopreference"
+        bingpg.import_keydata(r.keydata)
 
     def test_rsa2048_explicit_type(self, datadir, bingpg):
-        d = datadir.parse_ac_header_from_email("rsa2048-explicit-type.eml")
-        assert d["addr"] == "alice@testsuite.autocrypt.org"
-        bingpg.import_keydata(b64decode(d["keydata"]))
+        r = datadir.parse_ac_header_from_email("rsa2048-explicit-type.eml")
+        assert r.error
+        assert not r.keydata
 
     def test_rsa2048_unknown_non_critical(self, datadir, bingpg):
-        d = datadir.parse_ac_header_from_email("rsa2048-unknown-non-critical.eml")
-        assert d["addr"] == "alice@testsuite.autocrypt.org"
-        assert d["_monkey"] == "ignore"
-        bingpg.import_keydata(b64decode(d["keydata"]))
+        r = datadir.parse_ac_header_from_email("rsa2048-unknown-non-critical.eml")
+        assert r.addr == "alice@testsuite.autocrypt.org"
+        assert r.extra_attr["_monkey"] == "ignore"
+        bingpg.import_keydata(r.keydata)
 
     def test_rsa2048_unknown_critical(self, datadir):
-        d = datadir.parse_ac_header_from_email("rsa2048-unknown-critical.eml")
-        l = mime.verify_ac_dict(d)
-        assert len(l) == 1
-        assert "unknown critical attr 'danger'" in l[0]
+        r = datadir.parse_ac_header_from_email("rsa2048-unknown-critical.eml")
+        assert "unknown critical attr 'danger'" in r.error
 
     def test_unknown_type(self, datadir):
-        d = datadir.parse_ac_header_from_email("unknown-type.eml")
-        l = mime.verify_ac_dict(d)
-        assert len(l) == 1
-        assert "unknown key type '7'" in l[0]
+        r = datadir.parse_ac_header_from_email("unknown-type.eml")
+        assert "unknown critical attr 'type'" in r.error

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import six
+import pytest
 from muacrypt import mime
 from base64 import b64decode
 
@@ -50,6 +51,17 @@ def test_make_and_parse_header_errors():
     d = mime.parse_ac_headervalue(h)
     assert "unknown key type" in mime.verify_ac_dict(d)[0]
     assert d == make_ac_dict(addr=addr, keydata=keydata, type="9")
+
+
+def test_get_delivered_to():
+    msg = mime.gen_mail_msg(From="a@a.org", To=["b@b.org"], _dto=True)
+    assert mime.get_delivered_to(msg) == "b@b.org"
+
+    msg = mime.gen_mail_msg(From="a@a.org", To=["b@b.org"], _dto=False)
+    assert mime.get_delivered_to(msg, "z@b.org") == "z@b.org"
+
+    with pytest.raises(ValueError):
+        mime.get_delivered_to(msg)
 
 
 class TestEmailCorpus:

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -30,9 +30,15 @@ def test_parse_message_from_string(datadir):
 
 
 def test_render(datadir):
-    msg = mime.parse_message_from_string(datadir.read("rsa2048-simple.eml"))
+    msg = datadir.get_mime("rsa2048-simple.eml")
     x = mime.render_mime_structure(msg)
     assert "text/plain" in x
+
+
+def test_render_filename_unicode(datadir):
+    msg = datadir.get_mime("multipart_fn_unicode.eml")
+    x = mime.render_mime_structure(msg)
+    assert "rsicht" in x
 
 
 def test_make_and_parse_header_value():
@@ -65,14 +71,20 @@ def test_get_delivered_to():
 
 
 @pytest.mark.parametrize("input,output", [
-    (b"Simple <x@x.org>", "x@x.org"),
-    (b"=?utf-8?Q?Bj=C3=B6rn?= <x@x.org>", "x@x.org"),
-    (b"x <x@i\366enig.net>", "x@i=F6enig.net"),
+    ("Simple <x@x.org>", "x@x.org"),
+    ("=?utf-8?Q?Bj=C3=B6rn?= <x@x.org>", "x@x.org"),
+    ("x <x@k\366nig.net>", "x@könig.net"),
 ])
 def test_parse_email_addr(input, output):
     addr = mime.parse_email_addr(input)
     assert isinstance(addr, six.text_type)
     assert addr == output
+
+
+@pytest.mark.parametrize("input", ["", "lkqwje", ";;"])
+def test_parse_ac_headervalue_bad_input(input):
+    r = mime.parse_ac_headervalue(input)
+    assert r.error
 
 
 class TestEmailCorpus:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pdbpp
 
 commands = 
-    pytest {posargs:--no-test-cache --with-gpg2}
+    pytest {posargs:--with-gpg2}
 
 [testenv:doc]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = True
 deps = 
     pytest
     pytest-localserver
+    pdbpp
 
 commands = 
     pytest {posargs:--no-test-cache --with-gpg2}


### PR DESCRIPTION
- addresses #22 by adding encrypt_mime/decrypt_mime API to account.

- fix lots of corner cases for mime parsing, also wrt to content-transfer-encoding and py2/py3 encodings

- strike unused code 

- renamed/refactored towards more consistency 

this is now able to process 44K mails of my mailbox, and also decrypt encrypted ones. 
