### PR TITLE
increase key size to 3072

### DIFF
--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -159,10 +159,10 @@ let's create a standard autocrypt key with gpg::
     # content of autocrypt_key.spec
 
     Key-Type: RSA
-    Key-Length: 2048
+    Key-Length: 3072
     Key-Usage: sign
     Subkey-Type: RSA
-    Subkey-Length: 2048
+    Subkey-Length: 3072
     Subkey-Usage: encrypt
     Name-Email: test@autocrypt.org
     Expire-Date: 0

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -200,10 +200,10 @@ class BinGPG(object):
     def gen_secret_key(self, emailadr):
         spec = "\n".join([
             "Key-Type: RSA",
-            "Key-Length: 2048",
+            "Key-Length: 3072",
             "Key-Usage: sign",
             "Subkey-Type: RSA",
-            "Subkey-Length: 2048",
+            "Subkey-Length: 3072",
             "Subkey-Usage: encrypt",
             "Name-Email: " + emailadr,
             "Expire-Date: 0",

--- a/tests/test_bingpg.py
+++ b/tests/test_bingpg.py
@@ -126,7 +126,7 @@ class TestBinGPG:
         assert len(decrypt_info) == 1
         k = decrypt_info[0]
         assert str(k)
-        assert k.bits == 2048
+        assert k.bits == 3072
         assert k.type == "RSA"
         assert k.date_created
         keyinfos = bingpg2.list_public_keyinfos(keyhandle)


### PR DESCRIPTION
I would expect the test
  test_transfer_key_and_encrypt_decrypt_roundtrip
to also indicate a keysize of 3072. However it says the
key was 2048. Will need to investigate.

refers to #27 