### PR TITLE
fix: deal with emails without a From header

### DIFF
--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -104,7 +104,8 @@ def parse_one_ac_header_from_string(string):
 def parse_one_ac_header_from_msg(msg, FromList=None):
     if msg.get_content_type() == 'multipart/report':
         return ACParseResult(error="Ignoring 'multipart/report' message.")
-    if len(email.utils.getaddresses(msg.get_all("From"))) > 1:
+    froms = msg.get_all("From") or []
+    if len(email.utils.getaddresses(froms)) > 1:
         return ACParseResult(error="Ignoring message with more than one address in From header.")
     results = []
     err_results = []


### PR DESCRIPTION
Not sure if this actually is what we want. We have some tests that use an email without a From header. They were failing previously.

But what does the spec say about emails without a from address? Are they even RFC 2822 compliant? Maybe should fix the tests instead?