### PR TITLE
encrypt with bot

### DIFF
--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -48,7 +48,8 @@ class InvocationFailure(Exception):
 
     def __str__(self):
         lines = ["GPG Command '%s' retcode=%d" % (self.cmd, self.ret)]
-        for name, olines in [("stdout:", self.out), ("stderr:", self.err)]:
+        for name, olines in [("stdout:", self.out.__str__()),
+                             ("stderr:", self.err)]:
             lines.append(name)
             for line in olines.splitlines():
                 lines.append("  " + line)

--- a/muacrypt/bingpg.py
+++ b/muacrypt/bingpg.py
@@ -323,7 +323,7 @@ class BinGPG(object):
             opts.extend(["--sign", "-u", signkey])
         if text:
             opts.extend(["--armor"])
-        print(opts)
+        # print(opts)
         return self._gpg_out(opts, input=data, encoding=None)
 
     def sign(self, data, keyhandle):

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -76,8 +76,10 @@ def bot_reply(ctx, smtp, fallback_delivto):
     log("")
     log("P.S.: my current key {} is in the Autocrypt header of this reply."
         .format(r.account.ownstate.keyhandle))
-    log("P.P.S.: For this reply the encryption recommendation is {}".format(
-        account.get_recommendation([From]).ui_recommendation()))
+
+    ui_recommendation = account.get_recommendation([From]).ui_recommendation()
+    log("P.P.S.: For this reply the encryption recommendation is {}"
+        .format(ui_recommendation))
 
     reply_msg = mime.gen_mail_msg(
         From=delivto, To=[From],
@@ -86,6 +88,9 @@ def bot_reply(ctx, smtp, fallback_delivto):
         Autocrypt=account.make_ac_header(delivto),
         payload=six.text_type(log), charset="utf8",
     )
+    if ui_recommendation == 'encrypt':
+        r = account.encrypt_mime(reply_msg, [From])
+        reply_msg = r.enc_msg
     if smtp:
         host, port = smtp.split(",")
         send_reply(host, int(port), reply_msg)

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -72,12 +72,21 @@ def bot_reply(ctx, smtp, fallback_delivto):
                 ps.addr, ps.public_keyhandle, ps.prefer_encrypt))
 
     log("\n")
+    reply_to_encrypted = False
+    if msg.get_content_type() == "multipart/encrypted":
+        log("Your message was encrypted.")
+        decrypted = account.decrypt_mime(msg)
+        log("It was encrypted to the following keys:{}".format(
+            decrypted.keyinfos))
+        reply_to_encrypted = True
+
     log("have a nice day, {}".format(delivto))
     log("")
     log("P.S.: my current key {} is in the Autocrypt header of this reply."
         .format(r.account.ownstate.keyhandle))
 
-    ui_recommendation = account.get_recommendation([From]).ui_recommendation()
+    recom = account.get_recommendation([From], reply_to_encrypted)
+    ui_recommendation = recom.ui_recommendation()
     log("P.P.S.: For this reply the encryption recommendation is {}"
         .format(ui_recommendation))
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -139,9 +139,6 @@ class TestBot:
         out = bcmd.run_ok(["bot-reply"], input=msg.as_string())
 
         reply_msg = mime.parse_message_from_string(out)
-        linematch(decode_body(reply_msg), """
-            *processed*account*default*
-        """)
         assert reply_msg["Subject"] == "Re: " + msg["Subject"]
         assert reply_msg["From"] == bcmd.bot_adr
         assert reply_msg["To"] == msg["From"]
@@ -149,7 +146,13 @@ class TestBot:
         r = mime.parse_ac_headervalue(reply_msg["Autocrypt"])
         assert r.addr == bcmd.bot_adr
         assert r.keydata
-        body = decode_body(reply_msg)
+
+        ac_sender.process_incoming(reply_msg)
+        decrypted = ac_sender.decrypt_mime(reply_msg)
+        body = decode_body(decrypted.dec_msg)
+        linematch(body, """
+            *processed*account*default*
+        """)
         assert "no Autocrypt header" not in body
         assert "prefer_encrypt=mutual" in body
         assert "recommendation is encrypt" in body

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -126,6 +126,37 @@ class TestBot:
         assert "recommendation is available" in body
         print(body)
 
+    def test_reply_to_encrypted(self, bcmd, ac_sender, linematch):
+        send_adr = ac_sender.adr
+        msg = mime.gen_mail_msg(
+            From=send_adr, To=[bcmd.bot_adr],
+            Autocrypt=ac_sender.ac_headerval,
+            Subject="hello", _dto=True)
+
+        out = bcmd.run_ok(["bot-reply"], input=msg.as_string())
+
+        reply_msg = mime.parse_message_from_string(out)
+        ac_sender.process_incoming(reply_msg)
+
+        msg2 = mime.gen_mail_msg(
+            From=send_adr, To=[bcmd.bot_adr],
+            Autocrypt=ac_sender.ac_headerval,
+            Subject="encrypted", _dto=True)
+
+        r = ac_sender.encrypt_mime(msg2, [bcmd.bot_adr])
+        out2 = bcmd.run_ok(["bot-reply"], input=r.enc_msg.as_string())
+        enc_reply_msg = mime.parse_message_from_string(out2)
+        ac_sender.process_incoming(enc_reply_msg)
+        decrypted = ac_sender.decrypt_mime(enc_reply_msg)
+        body = decode_body(decrypted.dec_msg)
+        print(body)
+        linematch(body, """
+            *processed*account*default*
+        """)
+        assert "no Autocrypt header" not in body
+        assert "prefer_encrypt=nopreference" in body
+        assert "recommendation is encrypt" in body
+
     def test_encrypted_if_mutual(self, bcmd, ac_sender, linematch):
         bcmd.run_ok(["mod-account", "default", "--prefer-encrypt=mutual"])
         ac_sender.modify(prefer_encrypt='mutual')


### PR DESCRIPTION
Note that in order to properly decrypt the message we first
need to process the AC Header so we have the key to verify
the signature.

If we leave out this step it will lead to a response code of
2 from gnupg and raise an unprintable InvocationFailure:

``` python
        if ret != 0 or (strict and err):
            raise self.InvocationFailure(ret, " ".join(args),
>                                        out=out, err=err)
E           muacrypt.bingpg.InvocationFailure: <unprintable InvocationFailure object>

.tox/py35/lib/python3.5/site-packages/muacrypt/bingpg.py:190
```

I will see if i can turn this into something printable as i believe
we might run into it more often.