### PR TITLE
WIP: Gossip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+0.8.0.dev5 - unreleased
+-----------------------
+
+- reply to multiple CC'ed recipients with the bot so we can test
+  gossip.
+
+- add Autocrypt-Gossip headers to mails with multiple recipients.
+
+- parse gossip headers with the bot.
+
+
+
+
 0.8.0.dev4
 ----------
 

--- a/muacrypt/__init__.py
+++ b/muacrypt/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = "0.8.0.dev9"
+__version__ = "0.8.0.dev11"

--- a/muacrypt/__init__.py
+++ b/muacrypt/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = "0.8.0.dev8"
+__version__ = "0.8.0.dev9"

--- a/muacrypt/__init__.py
+++ b/muacrypt/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = "0.8.0.dev6"
+__version__ = "0.8.0.dev8"

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -355,10 +355,9 @@ class Account:
             if pah is not None:
                 peerstate = self.get_peerstate(recipient)
                 keyhandle = self._import_key(pah)
-                peerstate.update_from_msg(
+                peerstate.update_from_msg_gossip(
                     msg_id=msg_id, effective_date=msg_date,
                     keydata=pah.keydata, keyhandle=keyhandle,
-                    prefer_encrypt='nopreference'
                 )
                 processed[recipient] = pah
         return processed

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -20,7 +20,8 @@ from .cmdline_utils import (
 def send_reply(host, port, msg):
     import smtplib
     smtp = smtplib.SMTP(host, port)
-    return smtp.sendmail(msg["From"], msg["To"], msg.as_string())
+    recipients = mime.get_target_emailadr(msg)
+    return smtp.sendmail(msg["From"], recipients, msg.as_string())
 
 
 @mycommand("bot-reply")
@@ -119,7 +120,7 @@ def bot_reply(ctx, smtp, fallback_delivto):
         payload=six.text_type(log), charset="utf8",
     )
     if ui_recommendation == 'encrypt':
-        r = account.encrypt_mime(reply_msg, [From])
+        r = account.encrypt_mime(reply_msg, [From] + newlist)
         reply_msg = r.enc_msg
     if smtp:
         host, port = smtp.split(",")

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -91,7 +91,7 @@ def bot_reply(ctx, smtp, fallback_delivto):
         .format(ui_recommendation))
 
     reply_msg = mime.gen_mail_msg(
-        From=delivto, To=[From],
+        From=delivto, To=[From], Cc=[msg["Cc"]],
         Subject="Re: " + msg["Subject"],
         _extra={"In-Reply-To": msg["Message-ID"]},
         Autocrypt=account.make_ac_header(delivto),

--- a/muacrypt/bot.py
+++ b/muacrypt/bot.py
@@ -105,7 +105,7 @@ def bot_reply(ctx, smtp, fallback_delivto):
         # loops between CCed bots)
         return
 
-    addrlist = mime.getaddresses(msg.get_all("Cc") + msg.get_all("To"))
+    addrlist = mime.get_target_fulladr(msg)
     newlist = []
     for realname, addr in set(addrlist):
         if addr and addr != delivto:

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -12,7 +12,7 @@ from .myattr import attrs, attrib, attrib_bytes_or_none, attrib_text_or_none
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.utils import formatdate, make_msgid
-from email.utils import getaddresses, formataddr  # noqa
+from email.utils import formataddr  # noqa
 from email.generator import _make_boundary
 import six
 
@@ -68,11 +68,12 @@ def indented_split(value, maxlen=78, indent="  "):
 
 
 def get_target_emailadr(msg):
-    l = []
-    tos = msg.get_all("to") + (msg.get_all("cc") or [])
-    for realname, emailadr in email.utils.getaddresses(tos):
-        l.append(emailadr)
-    return l
+    return [x[1] for x in get_target_fulladr(msg)]
+
+
+def get_target_fulladr(msg):
+    tos = (msg.get_all("to") or []) + (msg.get_all("cc") or [])
+    return email.utils.getaddresses(tos)
 
 
 def parse_email_addr(string):
@@ -220,7 +221,8 @@ def gen_mail_msg(From, To, Cc=None, _extra=None, Autocrypt=None,
 
     msg['From'] = From
     msg['To'] = ",".join(To)
-    msg['Cc'] = ",".join(Cc)
+    if Cc:
+        msg['Cc'] = ",".join(Cc)
     msg['Message-ID'] = MessageID
     msg['Subject'] = Subject
     msg['Date'] = Date or formatdate()

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -97,6 +97,14 @@ def parse_message_from_string(string):
     return parse_message_from_file(stream)
 
 
+def is_encrypted(msg):
+    if msg.get_content_type() == "multipart/encrypted":
+        parts = msg.get_payload()
+        return (len(parts) == 2
+            and parts[0].get_content_type() == 'application/pgp-encrypted'
+            and parts[1].get_content_type() == 'application/octet-stream')
+
+
 def parse_one_ac_header_from_string(string):
     msg = parse_message_from_string(string)
     return parse_one_ac_header_from_msg(msg)

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -12,6 +12,7 @@ from .myattr import attrs, attrib, attrib_bytes_or_none, attrib_text_or_none
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.utils import formatdate, make_msgid
+from email.utils import getaddresses, formataddr  # noqa
 from email.generator import _make_boundary
 import six
 
@@ -226,8 +227,10 @@ def gen_mail_msg(From, To, Cc=None, _extra=None, Autocrypt=None,
     if _extra:
         for name, value in _extra.items():
             msg.add_header(name, value)
-    if _dto:
+    if _dto is True:
         msg["Delivered-To"] = To[0]
+    elif isinstance(_dto, six.text_type):
+        msg["Delivered-To"] = _dto
     if Autocrypt:
         msg["Autocrypt"] = Autocrypt
     return msg

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -176,10 +176,12 @@ class ACParseResult(object):
     error = attrib_text_or_none()
 
 
-def gen_mail_msg(From, To, _extra=None, Autocrypt=None, Subject="testmail",
-                 Date=None, _dto=False, MessageID=None, payload='Autoresponse\n',
+def gen_mail_msg(From, To, Cc=[], _extra=None, Autocrypt=None,
+                 Subject="testmail", Date=None, _dto=False,
+                 MessageID=None, payload='Autoresponse\n',
                  charset=None):
     assert isinstance(To, (list, tuple))
+    assert isinstance(Cc, (list, tuple))
     if MessageID is None:
         MessageID = make_msgid()
 
@@ -191,6 +193,7 @@ def gen_mail_msg(From, To, _extra=None, Autocrypt=None, Subject="testmail",
 
     msg['From'] = From
     msg['To'] = ",".join(To)
+    msg['Cc'] = ",".join(Cc)
     msg['Message-ID'] = MessageID
     msg['Subject'] = Subject
     msg['Date'] = Date or formatdate()

--- a/muacrypt/mime.py
+++ b/muacrypt/mime.py
@@ -4,6 +4,7 @@
 """Mime message parsing and manipulation functions for Autocrypt usage. """
 
 from __future__ import unicode_literals, print_function
+import logging
 import email.parser
 import base64
 import quopri
@@ -126,21 +127,16 @@ def parse_one_ac_header_from_msg(msg, FromList=None):
         return ACParseResult(error="no valid Autocrypt header found")
 
 
-def get_gossip_headers_from_msg(msg, recipients):
+def get_gossip_headers_from_msg(msg):
     results = {}
-    err_results = []
     for ac_header_value in msg.get_all("Autocrypt-Gossip") or []:
         r = parse_ac_headervalue(ac_header_value)
-        if not r.error and (r.addr in recipients):
+        if not r.error:
             results[r.addr] = r
         else:
-            err_results.append(r)
+            logging.error(r.error)
 
-    if results:
-        return results
-    if err_results:
-        return err_results[0]
-    return ACParseResult(error="no valid Autocrypt Gossip header found")
+    return results
 
 
 def parse_ac_headervalue(value):

--- a/muacrypt/recommendation.py
+++ b/muacrypt/recommendation.py
@@ -44,8 +44,11 @@ class PeerRecommendation:
             return 'encrypt'
         return pre
 
+    def _get_direct_keyhandle(self):
+        return getattr(self.peer, 'public_keyhandle', None)
+
     def target_keyhandle(self):
-        kh = getattr(self.peer, 'public_keyhandle', None)
+        kh = self._get_direct_keyhandle()
         if kh:
             return kh
         ge = self.peer.latest_gossip_entry()
@@ -54,6 +57,8 @@ class PeerRecommendation:
     def _preliminary_recommendation(self):
         if self.target_keyhandle() is None:
             return 'disable'
+        if not self._get_direct_keyhandle():
+            return 'discourage'
         timeout = 35 * 24 * 60 * 60
         if (self.peer.last_seen - self.peer.autocrypt_timestamp >
                 timeout):

--- a/muacrypt/recommendation.py
+++ b/muacrypt/recommendation.py
@@ -45,8 +45,11 @@ class PeerRecommendation:
         return pre
 
     def target_keyhandle(self):
-        return (getattr(self.peer, 'public_keyhandle', None) or
-                getattr(self.peer, 'gossip_keyhandle', None))
+        kh = getattr(self.peer, 'public_keyhandle', None)
+        if kh:
+            return kh
+        ge = self.peer.latest_gossip_entry()
+        return getattr(ge, "keyhandle", None)
 
     def _preliminary_recommendation(self):
         if self.target_keyhandle() is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,8 @@ def datadir(request):
 
         def parse_ac_header_from_email(self, name):
             msg = self.get_mime(name)
-            return mime.parse_one_ac_header_from_msg(msg)
+            From = mime.parse_email_addr(msg["From"])
+            return mime.parse_one_ac_header_from_msg(msg, FromList=[From])
 
     return D(request.fspath.dirpath("data"))
 

--- a/tests/data/rsa2048-from-not-match.eml
+++ b/tests/data/rsa2048-from-not-match.eml
@@ -1,0 +1,34 @@
+Delivered-To: <bob@testsuite.autocrypt.org>
+From: Alice <alice@testsuite.autocrypt.org>
+To: Bob <bob@testsuite.autocrypt.org>
+Subject: an Autocrypt RSA test
+Autocrypt: addr=notmatch@testsuite.autocrypt.org; keydata=
+ mQENBFhVF+ABCADu17FBUgA3mCemeKbNaBTyWe3VGxjbu7fUyHgdLK7i3tnd7IRtxQy/AEN2t6Vq
+ 0/xeZEAKYRInsHI/HjvmhqPeWFzipk71jRQ02WUY1pZytFjYNIrTdMk4eLYdC1N0go83PU33V4R8
+ fc2fWHD8N5JPsDH2xOB6WNWkMPxgMbtGIa0QTx7TINhDif4/1/VcrX3wz1gZ6xYI+sujbC54iBZo
+ qbEfu4SFVvp53d+a1plxBzuZ/X6nqJqcysiS7ORMieBvU6W/mVeiAxwN4qcAI5s+rGmRnP8ltONK
+ /P1ScH6lmELgqm8Z/M0wdiYgywme/bdEQOg3s0S/8nCIFmwUchN7ABEBAAG0HWFsaWNlQHRlc3Rz
+ dWl0ZS5hdXRvY3J5cHQub3JniQFOBBMBCAA4FiEEfi47NkGai9tG9hBruvxTPNmTvX8FAlhVF+AC
+ GwMFCwkIBwIGFQgJCgsCBBYCAwECHgECF4AACgkQuvxTPNmTvX/k4wf+JJZ0M0rZeAXbnxdR6HDU
+ ZYL734Z8x/HRpz3vzK4VQQJ4oIbUQPwydZmAlTlglQY48IWWOdJnYvn2pIhlTM/T8q9ZfmOyp6i1
+ jxFCPT+2ma4DjNOqYFhfnULE/MYc6xeVaBcwGj7yvAW7YY7156/wDo6+9TCd/a9mzOFCGS0yQoRa
+ K3uDajA+G/SmbC8t/3X8+5sapvi9Ru0HNkIzaj1jhH+kW6628E7nkf9aN9LodXHfs1UtfuLqM8VG
+ Ysk9474x9QxbsrJ4YvXeFwM9zAs+Pvj4lnpH/0WOU8jJc3uarluGH58kTHM5/5+p0TeMpOHX7OEw
+ JndsBOV9gFc6FMx4hLkBDQRYVRfiAQgA3ad+Aat4UY8xvQQutLYb8e417XZN1zVmKypyReB0l0Zf
+ HA6Qc7uxnJQ7dzIEZAxdnjvTYJaCFrOCBXAyPHpShVMpKqQP+kBBY/WiC3BSUALR3xqp7k5/sjLD
+ +K4dAacXEc7nyXP5o5+oqBXEH8Ls5X440c9A3EdsvVlncvSW5ILLItlFHmQd6f1ynnjK+FQwYJRJ
+ ypDuqJpYkA1vn7+XxeQShpX105rM3C8tJUxRAP3QFimenn4Zm2BDhQpCneuBt239rkXOAXsR0PnJ
+ fV8eNAEsE8IIqnPoSlBme5DZAri69+joYmTeSKGuj4aoxzDlx1AQigwpMISLciTXLnJypwARAQAB
+ iQE2BBgBCAAgFiEEfi47NkGai9tG9hBruvxTPNmTvX8FAlhVF+ICGwwACgkQuvxTPNmTvX8dOwf9
+ H72BGoYJkuuFrbQ6F/mH7gG9z3ytQHRD2Z0ja+3O7YnJBpotHFFjF7yHGj0FtmQR0Q7KnhkJ/3mv
+ fkvuaH3Gcjli/E7VASastuFDFkGANLmGZVGQQ2iTYFG1aejjtGb01vcaPrgE9WDueMB+Pn6/QbDc
+ 5SWCrVWrRFZKrwbAGw35GySoFYpxXyCNsk6q6Db56plllPZjrYj7axF0yN536D1ntEVFDOdKZq8x
+ Tb9P/4Tq9NKRLE4+aO6qCqEOz+V1OeOvYLw58BfnzXY8rXF93D/86YLyilv6p5WGaS/cRhIzr+Xq
+ +qBLD/vW+dh72e8MvcduX3tXV3Vkg0mkGekdOw==
+Date: Sat, 17 Dec 2016 10:07:48 +0100
+Message-ID: <rsa2048-from-not-match@testsuite.autocrypt.org>
+MIME-Version: 1.0
+Content-Type: text/plain
+
+This contains a "addr" in the Autocrypt header that does not match the "From"
+The autocrypt header should be ignored

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -272,14 +272,15 @@ class TestAccount:
 
         r = sender.encrypt_mime(gossip_msg, [rec.addr for rec in recipients])
         recipient = recipients[0]
+        other = recipients[1]
         recipient.process_incoming(r.enc_msg)
 
         # decrypt the incoming mail
         r = recipient.decrypt_mime(r.enc_msg)
         dec = r.dec_msg
-        assert dec.get_content_type() == "text/plain"
-        assert dec.get_payload() == gossip_msg.get_payload()
-        assert dec.get_payload(decode=True) == gossip_msg.get_payload(decode=True)
+        r = recipient.process_incoming_gossip(dec)
+        key = other.bingpg.get_public_keydata(other.ownstate.keyhandle)
+        assert r.peerstate[other.addr].public_keydata == key
 
 
 class TestAccountManager:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -197,7 +197,7 @@ class TestAccount:
         s = r2.dec_msg.get_payload(decode=True)
         assert six.text_type(s, "iso-8859-1") == u"angehört\n"
 
-    def test_encrypt_decrypt_mime_text_plain(self, account_maker, maildir):
+    def test_encrypt_decrypt_mime_text_plain(self, account_maker):
         acc1, acc2 = account_maker(), account_maker()
 
         # send a mail from addr1 with autocrypt key to addr2
@@ -218,7 +218,7 @@ class TestAccount:
         assert dec.get_payload() == msg2.get_payload()
         assert dec.get_payload(decode=True) == msg2.get_payload(decode=True)
 
-    def test_encrypt_decrypt_mime_mixed(self, account_maker, maildir):
+    def test_encrypt_decrypt_mime_mixed(self, account_maker):
         acc1, acc2 = account_maker(), account_maker()
 
         # send a mail from addr1 with autocrypt key to addr2
@@ -256,27 +256,49 @@ class TestAccount:
             assert recommend.ui_recommendation() == 'available'
             assert recommend.target_keyhandles()[sender.addr] == sender.ownstate.keyhandle
 
-    def test_encrypt_with_gossip(self, account_maker, maildir):
+    def test_encrypt_with_gossip(self, account_maker):
         sender = account_maker()
-        recipients = [account_maker(), account_maker()]
+        rec1, rec2 = account_maker(), account_maker()
 
         # make sure sender has all keys
-        for recipient in recipients:
-            msg = gen_ac_mail_msg(recipient, sender)
-            r = sender.process_incoming(msg)
-            assert r.peerstate.addr == recipient.addr
+        sender.process_incoming(gen_ac_mail_msg(rec1, sender))
+        sender.process_incoming(gen_ac_mail_msg(rec2, sender))
 
         # send an encrypted mail from sender to both recipients
-        gossip_msg = gen_ac_mail_msg(sender, recipients,
-                                     payload="hello ä umlaut", charset="utf8")
+        gossip_msg = gen_ac_mail_msg(sender, [rec1, rec2])
+        enc_msg = sender.encrypt_mime(gossip_msg, [rec1.addr, rec2.addr]).enc_msg
+        r = rec1.process_incoming(enc_msg)
 
-        r = sender.encrypt_mime(gossip_msg, [rec.addr for rec in recipients])
-        recipient = recipients[0]
-        other = recipients[1]
-        key = other.bingpg.get_public_keydata(other.ownstate.keyhandle)
+        ps = rec1.get_peerstate(rec2.addr)
+        ge = ps.latest_gossip_entry()
+        assert ge.keyhandle == rec2.ownstate.keyhandle
+        assert r.gossip_pahs[rec2.addr].keydata == ge.keydata
+        assert not ps.public_keydata  # no direct key
 
-        r = recipient.process_incoming(r.enc_msg)
-        assert r.gossip_pahs[other.addr].keydata == key
+    def test_gossip_leaves_direct_key_alone(self, account_maker):
+        sender = account_maker()
+        rec1, rec2 = account_maker(), account_maker()
+        # sender gets all keys directly
+        sender.process_incoming(gen_ac_mail_msg(rec1, sender))
+        sender.process_incoming(gen_ac_mail_msg(rec2, sender))
+
+        # rec2 changes its key
+        rec2new = account_maker()
+        rec2new.addr = rec2.addr
+        assert rec2new.ownstate.keyhandle != rec2.ownstate.keyhandle
+
+        # one recipient gets a direct key from the other
+        rec1.process_incoming(gen_ac_mail_msg(rec2new, rec1))
+        ps = rec1.get_peerstate(rec2new.addr)
+        assert ps.public_keyhandle == rec2new.ownstate.keyhandle
+
+        # send an encrypted mail from sender to both recipients
+        gossip_msg = gen_ac_mail_msg(sender, [rec1, rec2])
+        enc_msg = sender.encrypt_mime(gossip_msg, [rec1.addr, rec2new.addr]).enc_msg
+        rec1.process_incoming(enc_msg)
+
+        ps = rec1.get_peerstate(rec2new.addr)
+        assert ps.public_keyhandle == rec2new.ownstate.keyhandle
 
 
 class TestAccountManager:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -273,14 +273,10 @@ class TestAccount:
         r = sender.encrypt_mime(gossip_msg, [rec.addr for rec in recipients])
         recipient = recipients[0]
         other = recipients[1]
-        recipient.process_incoming(r.enc_msg)
-
-        # decrypt the incoming mail
-        r = recipient.decrypt_mime(r.enc_msg)
-        dec = r.dec_msg
-        r = recipient.process_gossip_headers(dec)
         key = other.bingpg.get_public_keydata(other.ownstate.keyhandle)
-        assert r.peerstate[other.addr].public_keydata == key
+
+        r = recipient.process_incoming(r.enc_msg)
+        assert r.gossip_pahs[other.addr].keydata == key
 
 
 class TestAccountManager:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -278,7 +278,7 @@ class TestAccount:
         # decrypt the incoming mail
         r = recipient.decrypt_mime(r.enc_msg)
         dec = r.dec_msg
-        r = recipient.process_incoming_gossip(dec)
+        r = recipient.process_gossip_headers(dec)
         key = other.bingpg.get_public_keydata(other.ownstate.keyhandle)
         assert r.peerstate[other.addr].public_keydata == key
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -126,6 +126,19 @@ class TestBot:
         assert "recommendation is available" in body
         print(body)
 
+    def test_reply_with_cc(self, bcmd, ac_sender, linematch):
+        send_adr = ac_sender.adr
+        msg = mime.gen_mail_msg(
+            From=send_adr, To=[bcmd.bot_adr],
+            Cc=['some@address.example'],
+            Autocrypt=ac_sender.ac_headerval,
+            Subject="hello", _dto=True)
+
+        out = bcmd.run_ok(["bot-reply"], input=msg.as_string())
+
+        reply_msg = mime.parse_message_from_string(out)
+        assert reply_msg["Cc"] == msg["Cc"]
+
     def test_reply_to_encrypted(self, bcmd, ac_sender, linematch):
         send_adr = ac_sender.adr
         msg = mime.gen_mail_msg(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -126,7 +126,7 @@ class TestBot:
         assert "recommendation is available" in body
         print(body)
 
-    def test_reply_with_cc(self, bcmd, ac_sender, linematch):
+    def test_reply_with_cc_and_to_bot(self, bcmd, ac_sender):
         send_adr = ac_sender.adr
         msg = mime.gen_mail_msg(
             From=send_adr, To=[bcmd.bot_adr],
@@ -135,9 +135,32 @@ class TestBot:
             Subject="hello", _dto=True)
 
         out = bcmd.run_ok(["bot-reply"], input=msg.as_string())
-
         reply_msg = mime.parse_message_from_string(out)
+        assert reply_msg["To"] == send_adr
         assert reply_msg["Cc"] == msg["Cc"]
+
+    def test_reply_with_cc_bot(self, bcmd, ac_sender):
+        send_adr = ac_sender.adr
+        msg = mime.gen_mail_msg(
+            From=send_adr, To=["some@address.example"],
+            Cc=[bcmd.bot_adr],
+            Autocrypt=ac_sender.ac_headerval,
+            Subject="hello", _dto=bcmd.bot_adr)
+
+        out = bcmd.run_ok(["bot-reply"], input=msg.as_string())
+        assert not out
+
+    def test_reply_puts_to_addresses_to_cc(self, bcmd, ac_sender, linematch):
+        send_adr = ac_sender.adr
+        msg = mime.gen_mail_msg(
+            From=send_adr, To=["bot2@example.org", bcmd.bot_adr],
+            Autocrypt=ac_sender.ac_headerval,
+            Subject="hello", _dto=bcmd.bot_adr)
+
+        out = bcmd.run_ok(["bot-reply"], input=msg.as_string())
+        reply_msg = mime.parse_message_from_string(out)
+        assert reply_msg["To"] == send_adr
+        assert reply_msg["Cc"] == "bot2@example.org"
 
     def test_reply_to_encrypted(self, bcmd, ac_sender, linematch):
         send_adr = ac_sender.adr

--- a/tests/test_mime.py
+++ b/tests/test_mime.py
@@ -51,6 +51,16 @@ def test_make_and_parse_header_value():
     assert not r.extra_attr
 
 
+def test_make_and_parse_header_value_with_full_addr():
+    addr, keydata = "name <x@xy.z>", b64encode(b'123')
+    h = mime.make_ac_header_value(addr=addr, keydata=keydata)
+    r = mime.parse_ac_headervalue(h)
+    assert not r.error
+    assert r.keydata == keydata
+    assert r.addr == "x@xy.z"
+    assert not r.extra_attr
+
+
 def test_make_and_parse_header_prefer_encrypt():
     addr, keydata = "x@xy.z", b64encode(b'123')
     h = mime.make_ac_header_value(addr=addr, keydata=keydata, prefer_encrypt="notset")
@@ -108,6 +118,10 @@ class TestEmailCorpus:
     def test_rsa2048_unknown_critical(self, datadir):
         r = datadir.parse_ac_header_from_email("rsa2048-unknown-critical.eml")
         assert "unknown critical attr 'danger'" in r.error
+
+    def test_rsa2048_from_not_match(self, datadir):
+        r = datadir.parse_ac_header_from_email("rsa2048-from-not-match.eml")
+        assert "does not match" in r.error
 
     def test_unknown_type(self, datadir):
         r = datadir.parse_ac_header_from_email("unknown-type.eml")

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -130,6 +130,10 @@ class TestRecommendation:
         # peer_keyhandle = composer.get_peerstate(peer.addr).public_keyhandle
         assert rec.ui_recommendation() == 'encrypt'
         assert rec.target_keyhandles()[peer2.addr]
+        rec = get_recommendation(peer1, peer2, reply_to_enc=False)
+        # peer_keyhandle = composer.get_peerstate(peer.addr).public_keyhandle
+        assert rec.ui_recommendation() == 'discourage'
+        assert rec.target_keyhandles()[peer2.addr]
 
     def test_disable_if_one_key_is_missing(self, account_maker):
         composer, peer = account_maker(), account_maker()

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -121,6 +121,16 @@ class TestRecommendation:
         assert rec.target_keyhandles()[peer.addr] == peer_keyhandle
         assert rec.ui_recommendation() == 'encrypt'
 
+    def test_gossip_keys_recommendation(self, account_maker):
+        composer, peer1, peer2 = account_maker(), account_maker(), account_maker()
+        send_ac_mail(peer1, composer)
+        send_ac_mail(peer2, composer)
+        send_enc_ac_mail(composer, [peer1, peer2])
+        rec = get_recommendation(peer1, peer2, reply_to_enc=True)
+        # peer_keyhandle = composer.get_peerstate(peer.addr).public_keyhandle
+        assert rec.ui_recommendation() == 'encrypt'
+        assert rec.target_keyhandles()[peer2.addr]
+
     def test_disable_if_one_key_is_missing(self, account_maker):
         composer, peer = account_maker(), account_maker()
         no_ac_peer = account_maker()

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -7,19 +7,19 @@ from muacrypt import mime
 def send_ac_mail(sender, recipient, Date=None):
     mail = mime.gen_mail_msg(
         From=sender.addr, To=[recipient.addr],
-        Autocrypt=sender.make_ac_header(recipient.addr),
+        Autocrypt=sender.make_ac_header(sender.addr),
         Date=Date)
     recipient.process_incoming(mail)
 
 
-def send_enc_ac_mail(sender, recipient):
+def send_enc_ac_mail(sender, recipients):
+    addrs = [r.addr for r in recipients]
     msg = mime.gen_mail_msg(
-        From=sender.addr, To=[recipient.addr],
-        Autocrypt=sender.make_ac_header(recipient.addr))
-    r = sender.encrypt_mime(msg, [recipient.addr])
-    recipient.process_incoming(r.enc_msg)
-    r = recipient.decrypt_mime(r.enc_msg)
-    return r.dec_msg
+        From=sender.addr, To=addrs,
+        Autocrypt=sender.make_ac_header(sender.addr))
+    r = sender.encrypt_mime(msg, addrs)
+    for rec in recipients:
+        rec.process_incoming(r.enc_msg)
 
 
 def send_no_ac_mail(sender, recipient):
@@ -115,7 +115,7 @@ class TestRecommendation:
     def test_encrypt_replies_to_encrypted(self, account_maker):
         composer, peer = account_maker(), account_maker()
         send_ac_mail(composer, peer)
-        send_enc_ac_mail(peer, composer)
+        send_enc_ac_mail(peer, [composer])
         rec = get_recommendation(composer, peer, reply_to_enc=True)
         peer_keyhandle = composer.get_peerstate(peer.addr).public_keyhandle
         assert rec.target_keyhandles()[peer.addr] == peer_keyhandle


### PR DESCRIPTION
This still needs quite a bit of cleanup and tests.
    
I think the header processing part could use some refactoring.
Processing incoming Autocrypt and Autocrypt-Gossip headers is
very similar.

Our internal data representation also does not destinguish gossip
and Autocrypt headers from the person themselves yet. Will need
to look into the update of the peerstate again.
    
We also lack tests for:
* [ ] handling multiple gossip headers for the same recipient
* [ ] ignoring gossip headers for email addresses that are not
      part of the recipients
    
