### PR TITLE
make account.get_recommendation and get_peerstate() APIs accept full …

### DIFF
--- a/muacrypt/__init__.py
+++ b/muacrypt/__init__.py
@@ -1,2 +1,2 @@
 #
-__version__ = "0.8.0.dev5"
+__version__ = "0.8.0.dev6"

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -199,9 +199,12 @@ class Account:
         return "Account(name={})".format(self.name)
 
     def get_peerstate(self, addr):
-        return self._states.get_peerstate(self.name, addr)
+        routable_addr = mime.parse_email_addr(addr)
+        return self._states.get_peerstate(self.name, routable_addr)
 
     def get_recommendation(self, addrs, reply_to_enc=False):
+        assert isinstance(addrs, (list, set, tuple)), addrs
+        addrs = map(mime.parse_email_addr, addrs)
         peerstates = {addr: self.get_peerstate(addr) for addr in addrs}
         return Recommendation(peerstates, self.ownstate.prefer_encrypt,
                               reply_to_enc=reply_to_enc)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -249,9 +249,10 @@ class TestAccount:
             From=sender.addr, To=[recipient.addr],
             Autocrypt=sender.make_ac_header(sender.addr))
         recipient.process_incoming(msg1)
-        recommend = recipient.get_recommendation({sender.addr})
-        assert recommend.ui_recommendation() == 'available'
-        assert recommend.target_keyhandles()[sender.addr] == sender.ownstate.keyhandle
+        for addr in [sender.addr, "someprefix <{}>".format(sender.addr)]:
+            recommend = recipient.get_recommendation([addr])
+            assert recommend.ui_recommendation() == 'available'
+            assert recommend.target_keyhandles()[sender.addr] == sender.ownstate.keyhandle
 
 
 class TestAccountManager:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -8,7 +8,7 @@ from muacrypt import mime
 from muacrypt.bot import SimpleLog
 
 
-@pytest.fixture(params=["sender@example.org"])
+@pytest.fixture(params=["sender@example.org", "sender <sender@example.org>"])
 def ac_sender(manager_maker, request):
     manager = manager_maker(init=False)
     account = manager.add_account("sender", email_regex=request.param)
@@ -231,6 +231,6 @@ class TestBot:
                 *processed incoming*
                 *{senderadr}*{senderkeyhandle}*
             """.format(
-                senderadr=ac_sender.adr,
+                senderadr=mime.parse_email_addr(ac_sender.adr),
                 senderkeyhandle=ac_sender.ownstate.keyhandle,
             ))


### PR DESCRIPTION
…and not just routable e-mail addresses