### PR TITLE
refine the process before encryption hook

### DIFF
--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -433,6 +433,7 @@ class Account:
             sender_keyhandle=self.ownstate.keyhandle,
             recipient2keydata=recipient2keydata,
             payload_msg=clear_payload_msg,
+            _account=self,
         )
 
         clear_data = mime.msg2bytes(clear_payload_msg)  # .replace(b'\n', b'\r\n') TBD for RFC?

--- a/muacrypt/account.py
+++ b/muacrypt/account.py
@@ -418,6 +418,7 @@ class Account:
         keyhandles = []
         recipient2keydata = {}
         clear_payload_msg = mime.make_content_message_from_email(msg)
+        toaddrs = [mime.parse_email_addr(t) for t in toaddrs]
         for addr in toaddrs:
             peer = self.get_peerstate(addr)
             kh = peer.public_keyhandle

--- a/muacrypt/hookspec.py
+++ b/muacrypt/hookspec.py
@@ -14,5 +14,15 @@ def process_incoming_gossip(addr2pagh, account_key, dec_msg):
 
 
 @hookspec
-def process_outgoing_before_encryption(account_key, msg):
-    """called encrypting outgoing message."""
+def process_before_encryption(sender_addr, sender_keyhandle,
+                              recipient2keydata, payload_msg):
+    """called before encrypting a mime message.
+
+    sender_addr is the routable e-mail address part of the sender.
+    sender_keyhandle is the keyhandle which is to be used for signing.
+    recipient2keydata is a dictionary mapping recipient routeable
+    addresses to their respective keydata.
+    payload_msg is the cleartext mime message -- you can add extra
+    headers to this (via .add_header(name, value)) which will be
+    encrypted along with the rest of the payload message.
+    """

--- a/muacrypt/hookspec.py
+++ b/muacrypt/hookspec.py
@@ -15,14 +15,20 @@ def process_incoming_gossip(addr2pagh, account_key, dec_msg):
 
 @hookspec
 def process_before_encryption(sender_addr, sender_keyhandle,
-                              recipient2keydata, payload_msg):
+                              recipient2keydata, payload_msg, _account):
     """called before encrypting a mime message.
 
     sender_addr is the routable e-mail address part of the sender.
+
     sender_keyhandle is the keyhandle which is to be used for signing.
+
     recipient2keydata is a dictionary mapping recipient routeable
     addresses to their respective keydata.
+
     payload_msg is the cleartext mime message -- you can add extra
     headers to this (via .add_header(name, value)) which will be
     encrypted along with the rest of the payload message.
+
+    _account is muacrypt's internal Account class. It's API is
+    not yet stable and might change/go away in future releases.
     """

--- a/test_muacrypt/conftest.py
+++ b/test_muacrypt/conftest.py
@@ -281,6 +281,7 @@ def account_maker(tmpdir, gpgpath):
         account.create(name=bname, email_regex=email_regex, gpgmode=gpgmode, gpgbin=gpgbin,
                        keyhandle=None)
         account.addr = "%d@x.org" % (i, )
+        account._fulladdr = "%s <%s>" % (bname, account.addr)
         return account
     return maker
 

--- a/test_muacrypt/test_hooks.py
+++ b/test_muacrypt/test_hooks.py
@@ -82,7 +82,7 @@ class TestPluginHooks:
         sender.plugin_manager.register(Plugin())
 
         # send an encrypted mail from sender to both recipients
-        enc_msg = sender.encrypt_mime(gossip_msg, [rec1.addr, rec2.addr]).enc_msg
+        enc_msg = sender.encrypt_mime(gossip_msg, [rec1._fulladdr, rec2.addr]).enc_msg
 
         assert len(l) == 1
         sender_addr, sender_keyhandle = l[0][:2]

--- a/test_muacrypt/test_hooks.py
+++ b/test_muacrypt/test_hooks.py
@@ -72,10 +72,10 @@ class TestPluginHooks:
         class Plugin:
             @hookimpl
             def process_before_encryption(self, sender_addr, sender_keyhandle,
-                                          recipient2keydata, payload_msg):
+                                          recipient2keydata, payload_msg, _account):
                 l.append((
                     sender_addr, sender_keyhandle,
-                    recipient2keydata, payload_msg,
+                    recipient2keydata, payload_msg, _account,
                 ))
                 payload_msg["My-Plugin-Header"] = "My own header"
 
@@ -86,7 +86,8 @@ class TestPluginHooks:
 
         assert len(l) == 1
         sender_addr, sender_keyhandle = l[0][:2]
-        recipient2keydata, payload_msg = l[0][2:]
+        recipient2keydata, payload_msg, _account = l[0][2:]
+        assert _account == sender
         assert sender_keyhandle == sender.ownstate.keyhandle
         assert sender_addr == sender.addr
         assert len(recipient2keydata) == 2

--- a/test_muacrypt/test_hooks.py
+++ b/test_muacrypt/test_hooks.py
@@ -7,6 +7,10 @@ from test_muacrypt.test_account import gen_ac_mail_msg
 hookimpl = pluggy.HookimplMarker("muacrypt")
 
 
+def get_own_pubkey(account):
+    return account.bingpg.get_public_keydata(account.ownstate.keyhandle)
+
+
 class TestPluginHooks:
     def test_get_account_pluggy_instantiate_account(self, manager_maker, datadir):
         manage1 = manager_maker()
@@ -51,11 +55,8 @@ class TestPluginHooks:
         assert rec1.addr in addr2pagh
         assert rec2.addr in addr2pagh
 
-        def getpk(account):
-            return account.bingpg.get_public_keydata(account.ownstate.keyhandle)
-
-        assert addr2pagh[rec1.addr].keydata == getpk(rec1)
-        assert addr2pagh[rec2.addr].keydata == getpk(rec2)
+        assert addr2pagh[rec1.addr].keydata == get_own_pubkey(rec1)
+        assert addr2pagh[rec2.addr].keydata == get_own_pubkey(rec2)
 
     def test_process_outgoing_calls_hook(self, account_maker):
         sender = account_maker()
@@ -70,9 +71,13 @@ class TestPluginHooks:
 
         class Plugin:
             @hookimpl
-            def process_outgoing_before_encryption(self, account_key, msg):
-                l.append((account_key, msg))
-                msg["Plugin-Header"] = "My own header"
+            def process_before_encryption(self, sender_addr, sender_keyhandle,
+                                          recipient2keydata, payload_msg):
+                l.append((
+                    sender_addr, sender_keyhandle,
+                    recipient2keydata, payload_msg,
+                ))
+                payload_msg["My-Plugin-Header"] = "My own header"
 
         sender.plugin_manager.register(Plugin())
 
@@ -80,9 +85,14 @@ class TestPluginHooks:
         enc_msg = sender.encrypt_mime(gossip_msg, [rec1.addr, rec2.addr]).enc_msg
 
         assert len(l) == 1
-        account_key, msg = l[0]
-        assert account_key == sender.ownstate.keyhandle
+        sender_addr, sender_keyhandle = l[0][:2]
+        recipient2keydata, payload_msg = l[0][2:]
+        assert sender_keyhandle == sender.ownstate.keyhandle
+        assert sender_addr == sender.addr
+        assert len(recipient2keydata) == 2
+        assert recipient2keydata[rec1.addr] == get_own_pubkey(rec1)
+        assert recipient2keydata[rec2.addr] == get_own_pubkey(rec2)
         assert enc_msg["Message-Id"] == gossip_msg["Message-Id"]
         rec1.process_incoming(enc_msg)
         dec_msg = rec1.decrypt_mime(enc_msg).dec_msg
-        assert dec_msg["Plugin-Header"] == "My own header"
+        assert dec_msg["My-Plugin-Header"] == "My own header"


### PR DESCRIPTION
note that the hook is now called "process_before_encrypt" because we don't really do it during process_outgiong and there might be an API usage of account.encrypt_mime() which does not send the mail out. 