### PR TITLE
fix: use gossip keys if no direct key is available

### DIFF
--- a/muacrypt/recommendation.py
+++ b/muacrypt/recommendation.py
@@ -44,20 +44,13 @@ class PeerRecommendation:
             return 'encrypt'
         return pre
 
-    def _get_direct_keyhandle(self):
-        return getattr(self.peer, 'public_keyhandle', None)
-
     def target_keyhandle(self):
-        kh = self._get_direct_keyhandle()
-        if kh:
-            return kh
-        ge = self.peer.latest_gossip_entry()
-        return getattr(ge, "keyhandle", None)
+        return getattr(self.peer.entry_for_encryption(), "keyhandle", None)
 
     def _preliminary_recommendation(self):
         if self.target_keyhandle() is None:
             return 'disable'
-        if not self._get_direct_keyhandle():
+        if not self.peer.has_direct_key():
             return 'discourage'
         timeout = 35 * 24 * 60 * 60
         if (self.peer.last_seen - self.peer.autocrypt_timestamp >

--- a/muacrypt/states.py
+++ b/muacrypt/states.py
@@ -126,15 +126,26 @@ class PeerState(object):
 
     @property
     def public_keyhandle(self):
-        return getattr(self._latest_ac_entry(), "keyhandle", '')
+        return getattr(self.entry_for_encryption(), "keyhandle", '')
 
     @property
     def public_keydata(self):
-        return getattr(self._latest_ac_entry(), "keydata", b'')
+        return getattr(self.entry_for_encryption(), "keydata", b'')
+
+    def has_direct_key(self):
+        return bool(getattr(self._latest_ac_entry(), "keyhandle", ''))
+
+    def entry_for_encryption(self):
+        direct = self._latest_ac_entry()
+        # TODO: perform propper checks on usability of ac entry here
+        if getattr(direct, "keyhandle", None):
+            return direct
+        else:
+            return self.latest_gossip_entry()
 
     @property
     def prefer_encrypt(self):
-        return getattr(self._latest_ac_entry(), "prefer_encrypt", '')
+        return getattr(self.entry_for_encryption(), "prefer_encrypt", '')
 
     def _latest_ac_entry(self):
         """ Return latest message with Autocrypt header. """


### PR DESCRIPTION
We were considering them in recommendation but not using them
when encrypting.