### PR TITLE
try fix #74 attempt to allow unicode for "To" addresses with "muacryp…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,11 @@
-0.8.0.dev5 - unreleased
+0.8.0
 -----------------------
 
 - reply to multiple CC'ed recipients with the bot so we can test
   gossip.
+
+- introduce plugin architecture with hooks on incoming/outgoing mail
+  and for adding new subcommands.
 
 - add Autocrypt-Gossip headers to mails with multiple recipients.
 
@@ -11,11 +14,6 @@
 - refine recommendations and add command line call
 
 - add way to add subcommands from a plugin
-
-
-
-0.8.0.dev4
-----------
 
 - moved repo to hpk42/py-autocrypt and refined entry pages to link
   to new IRC channel and mailing list and describe the aims.

--- a/muacrypt/cmdline.py
+++ b/muacrypt/cmdline.py
@@ -277,7 +277,7 @@ def sendmail(ctx, args):
     input = msg.as_string()
     # with open("/tmp/mail", "w") as f:
     #    f.write(input)
-    log_info("piping to: {}".format(" ".join(args)))
+    log_info(u"piping to: {}".format(" ".join(args)))
     sendmail = find_executable("sendmail")
     if not sendmail:
         sendmail = "/usr/sbin/sendmail"

--- a/test_muacrypt/test_cmdline.py
+++ b/test_muacrypt/test_cmdline.py
@@ -1,7 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim:ts=4:sw=4:expandtab
+
 from __future__ import print_function, unicode_literals
 import os
 import re
 import six
+import pytest
 from muacrypt import mime
 
 
@@ -151,6 +155,7 @@ class TestAccountCommands:
 
 
 class TestProcessOutgoing:
+
     def test_simple(self, mycmd, gen_mail):
         mycmd.run_ok(["add-account", "home"])
         mail = gen_mail()
@@ -190,10 +195,11 @@ class TestProcessOutgoing:
         x2 = mime.parse_ac_headervalue(gen_header)
         assert x1 == x2
 
-    def test_sendmail(self, mycmd, gen_mail, popen_mock):
+    @pytest.mark.parametrize("addr", ["a@a.org", "ño@example.org"])
+    def test_sendmail(self, mycmd, gen_mail, popen_mock, addr):
         mycmd.run_ok(["add-account", "account1"])
         mail = gen_mail().as_string()
-        pargs = ["-oi", "b@b.org"]
+        pargs = ["-oi", addr]
         mycmd.run_ok(["sendmail", "-f", "--"] + pargs, input=mail)
         assert len(popen_mock.calls) == 1
         call = popen_mock.pop_next_call()


### PR DESCRIPTION
…t sendmail". it's not a fully functional test as we don't invoke a full shell environment .